### PR TITLE
Allow setting completion date without creation date (for ttdl #97)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TODO Library 
+# TODO Library
 
 ![](https://travis-ci.com/VladimirMarkelov/todo_lib.svg?branch=master)
 [![](https://img.shields.io/crates/v/todo_lib.svg)](https://crates.io/crates/todo_lib)
@@ -88,7 +88,7 @@ Functions of this category gets a list of all todos, list of todo IDs that shoul
 
 ##### Mark a todo completed
 
-`done(tasks: &mut TaskVec, ids: Option<&IDVec>, mode: todotxt::CompletionMode) -> ChangedVec`
+`done_with_config(tasks: &mut TaskVec, ids: Option<&IDVec>, completion_config: todotxt::CompletionConfig) -> ChangedVec`
 
 Makes all todos from `ids` list that are incomplete completed.
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -46,8 +46,8 @@ pub fn start_timer(task: &mut todotxt::Task) -> bool {
 fn calc_time_spent(task: &todotxt::Task) -> Option<i64> {
     if let Some(started) = task.tags.get(todo::TIMER_TAG) {
         if let Ok(n) = started.parse::<i64>() {
-            let dt_start = chrono::NaiveDateTime::from_timestamp_opt(n, 0)?;
-            let diff = chrono::Utc::now().naive_utc() - dt_start;
+            let dt_start = chrono::DateTime::from_timestamp(n, 0)?;
+            let diff = chrono::Utc::now() - dt_start;
 
             let mut spent: i64 =
                 if let Some(sp) = task.tags.get(todo::SPENT_TAG) { sp.parse::<i64>().unwrap_or(0) } else { 0 };

--- a/src/todo.rs
+++ b/src/todo.rs
@@ -12,6 +12,7 @@ use std::path::Path;
 use crate::terr;
 use crate::timer;
 use crate::todotxt;
+use crate::todotxt::CompletionConfig;
 use crate::tsort;
 
 /// The ID value returned instead of new todo ID if adding a new todo fails
@@ -121,6 +122,8 @@ pub struct Conf {
     pub hashtags_act: Action,
     /// Rule to update priority when a task is done or undone
     pub completion_mode: todotxt::CompletionMode,
+    /// Rule to set a completion date when a task is done
+    pub completion_date_mode: todotxt::CompletionDateMode,
 }
 
 impl Default for Conf {
@@ -146,6 +149,7 @@ impl Default for Conf {
             hashtags: None,
             hashtags_act: Action::None,
             completion_mode: todotxt::CompletionMode::JustMark,
+            completion_date_mode: todotxt::CompletionDateMode::WhenCreateDateIsPresent
         }
     }
 }
@@ -286,7 +290,11 @@ fn done_undone(tasks: &mut TaskVec, ids: Option<&IDVec>, c: &Conf) -> ChangedVec
         if c.done {
             bools[i] = timer::stop_timer(&mut tasks[*idx]);
             let mut next_task = (tasks[*idx]).clone();
-            let completed = tasks[*idx].complete(now, c.completion_mode);
+            let completion_config = CompletionConfig {
+                completion_mode: c.completion_mode,
+                completion_date_mode: c.completion_date_mode
+            };
+            let completed = tasks[*idx].complete_with_config(now, completion_config);
             if completed
                 && next_task.recurrence.is_some()
                 && (next_task.due_date.is_some() || next_task.threshold_date.is_some())
@@ -324,8 +332,37 @@ fn done_undone(tasks: &mut TaskVec, ids: Option<&IDVec>, c: &Conf) -> ChangedVec
 /// The length of the result list equals either length of `ids`(if `ids` is
 /// `Some`) or  length of `tasks`(if `ids` is `None`). Value `true` in this
 /// array means that corresponding item from `ids` or `tasks` was modified.
+#[deprecated(note="Use `done_with_config` instead, it has more stable api and more options")]
 pub fn done(tasks: &mut TaskVec, ids: Option<&IDVec>, mode: todotxt::CompletionMode) -> ChangedVec {
     let c = Conf { done: true, completion_mode: mode, ..Default::default() };
+    done_undone(tasks, ids, &c)
+}
+
+/// Marks todos completed.
+///
+/// It works differently for regular and recurrent ones.
+/// If a todo is a regular one and is not done yet, the function sets flag
+/// `done` and marks the todo as modified.
+/// If a todo is a recurrent one and any of due and threshold dates exist,
+/// the function marks the current task done and appends a new task with
+/// changed due and threshold dates (current values increased by recurrence value).
+///
+/// * `tasks` - the task list
+/// * `ids` - the list of todo IDs which should be completed. If it is `None`
+///     the entire task list is marked completed
+/// * `completion_config` = how additional fields are set during completion (see todotxt::CompletionConfig)
+///
+/// Returns a list of boolean values: a value per each ID in `ids` or `tasks`.
+/// The length of the result list equals either length of `ids`(if `ids` is
+/// `Some`) or  length of `tasks`(if `ids` is `None`). Value `true` in this
+/// array means that corresponding item from `ids` or `tasks` was modified.
+pub fn done_with_config(tasks: &mut TaskVec, ids: Option<&IDVec>, completion_config: todotxt::CompletionConfig) -> ChangedVec {
+    let c = Conf {
+        done: true,
+        completion_mode: completion_config.completion_mode,
+        completion_date_mode: completion_config.completion_date_mode,
+        ..Default::default()
+    };
     done_undone(tasks, ids, &c)
 }
 

--- a/src/todo.rs
+++ b/src/todo.rs
@@ -149,7 +149,7 @@ impl Default for Conf {
             hashtags: None,
             hashtags_act: Action::None,
             completion_mode: todotxt::CompletionMode::JustMark,
-            completion_date_mode: todotxt::CompletionDateMode::WhenCreateDateIsPresent
+            completion_date_mode: todotxt::CompletionDateMode::WhenCreationDateIsPresent,
         }
     }
 }
@@ -290,10 +290,8 @@ fn done_undone(tasks: &mut TaskVec, ids: Option<&IDVec>, c: &Conf) -> ChangedVec
         if c.done {
             bools[i] = timer::stop_timer(&mut tasks[*idx]);
             let mut next_task = (tasks[*idx]).clone();
-            let completion_config = CompletionConfig {
-                completion_mode: c.completion_mode,
-                completion_date_mode: c.completion_date_mode
-            };
+            let completion_config =
+                CompletionConfig { completion_mode: c.completion_mode, completion_date_mode: c.completion_date_mode };
             let completed = tasks[*idx].complete_with_config(now, completion_config);
             if completed
                 && next_task.recurrence.is_some()
@@ -332,7 +330,7 @@ fn done_undone(tasks: &mut TaskVec, ids: Option<&IDVec>, c: &Conf) -> ChangedVec
 /// The length of the result list equals either length of `ids`(if `ids` is
 /// `Some`) or  length of `tasks`(if `ids` is `None`). Value `true` in this
 /// array means that corresponding item from `ids` or `tasks` was modified.
-#[deprecated(note="Use `done_with_config` instead, it has more stable api and more options")]
+#[deprecated(note = "Use `done_with_config` instead, it has more stable api and more options")]
 pub fn done(tasks: &mut TaskVec, ids: Option<&IDVec>, mode: todotxt::CompletionMode) -> ChangedVec {
     let c = Conf { done: true, completion_mode: mode, ..Default::default() };
     done_undone(tasks, ids, &c)
@@ -356,7 +354,11 @@ pub fn done(tasks: &mut TaskVec, ids: Option<&IDVec>, mode: todotxt::CompletionM
 /// The length of the result list equals either length of `ids`(if `ids` is
 /// `Some`) or  length of `tasks`(if `ids` is `None`). Value `true` in this
 /// array means that corresponding item from `ids` or `tasks` was modified.
-pub fn done_with_config(tasks: &mut TaskVec, ids: Option<&IDVec>, completion_config: todotxt::CompletionConfig) -> ChangedVec {
+pub fn done_with_config(
+    tasks: &mut TaskVec,
+    ids: Option<&IDVec>,
+    completion_config: todotxt::CompletionConfig,
+) -> ChangedVec {
     let c = Conf {
         done: true,
         completion_mode: completion_config.completion_mode,

--- a/src/todotxt/task.rs
+++ b/src/todotxt/task.rs
@@ -12,14 +12,14 @@ pub struct CompletionConfig {
     /// What to do with priority on task completion.
     pub completion_mode: CompletionMode,
     /// How to set completion date on task completion.
-    pub completion_date_mode: CompletionDateMode
+    pub completion_date_mode: CompletionDateMode,
 }
 
 impl Default for CompletionConfig {
     fn default() -> Self {
         Self {
             completion_mode: CompletionMode::JustMark,
-            completion_date_mode: CompletionDateMode::WhenCreateDateIsPresent
+            completion_date_mode: CompletionDateMode::WhenCreationDateIsPresent,
         }
     }
 }
@@ -43,10 +43,10 @@ pub enum CompletionMode {
 /// How to set completion date on task completion.
 #[derive(PartialEq, Debug, Clone, Copy)]
 pub enum CompletionDateMode {
-    /// Only add completion date if task has create date is specified.
-    WhenCreateDateIsPresent,
-    /// Always add completion date, regardless of whether or not create date is present
-    AlwaysSet
+    /// Only add completion date if task has creation date
+    WhenCreationDateIsPresent,
+    /// Always add completion date, regardless of whether or not creation date is present
+    AlwaysSet,
 }
 
 #[derive(PartialEq, Eq, Debug, Clone)]
@@ -337,7 +337,7 @@ impl Task {
 
     /// Mark the task completed.
     /// Returns true if the task was changed(e.g., for a completed task the function return false).
-    #[deprecated(note="Please use `complete_with_config` - it has more stable API")]
+    #[deprecated(note = "Please use `complete_with_config` - it has more stable API")]
     pub fn complete(&mut self, date: NaiveDate, cmpl: CompletionMode) -> bool {
         self.complete_with_config(date, CompletionConfig { completion_mode: cmpl, ..Default::default() })
     }

--- a/tests/task.rs
+++ b/tests/task.rs
@@ -1,5 +1,5 @@
 use chrono::NaiveDate;
-use todo_lib::todotxt::{business_days_between, CompletionMode, Task};
+use todo_lib::todotxt::{business_days_between, CompletionConfig, CompletionDateMode, CompletionMode, Task};
 
 #[test]
 fn parse_tasks_simple() {
@@ -141,7 +141,8 @@ fn parse_tasks_tags() {
 }
 
 #[test]
-fn complete_uncomplete() {
+#[allow(deprecated)]
+fn complete_old_signature() {
     struct Test {
         i: &'static str,
         d: &'static str,
@@ -211,6 +212,155 @@ fn complete_uncomplete() {
         }
     }
 }
+
+#[test]
+fn complete_uncomplete() {
+    struct Test {
+        i: &'static str,
+        d: &'static str,
+        u: &'static str,
+        m: CompletionMode,
+        cdm: CompletionDateMode
+    }
+    let data: Vec<Test> = vec![
+        Test {
+            i: "test",
+            d: "x test",
+            u: "test",
+            m: CompletionMode::JustMark,
+            cdm: CompletionDateMode::WhenCreateDateIsPresent,
+        },
+        Test {
+            i: "test",
+            d: "x 2020-02-02 test",
+            u: "test",
+            m: CompletionMode::JustMark,
+            cdm: CompletionDateMode::AlwaysSet,
+        },
+        Test {
+            i: "2020-01-01 test",
+            d: "x 2020-02-02 2020-01-01 test",
+            u: "2020-01-01 test",
+            m: CompletionMode::JustMark,
+            cdm: CompletionDateMode::WhenCreateDateIsPresent,
+        },
+        Test {
+            i: "test rec:+1m due:2020-03-01",
+            d: "x test rec:+1m due:2020-03-01",
+            u: "test rec:+1m due:2020-03-01",
+            m: CompletionMode::JustMark,
+            cdm: CompletionDateMode::WhenCreateDateIsPresent,
+        },
+        Test {
+            i: "test rec:1m due:2020-03-01",
+            d: "x test rec:1m due:2020-03-01",
+            u: "test rec:1m due:2020-03-01",
+            m: CompletionMode::JustMark,
+            cdm: CompletionDateMode::WhenCreateDateIsPresent,
+        },
+        Test {
+            i: "test rec:1m due:2020-03-01",
+            d: "x test rec:1m due:2020-03-01",
+            u: "test rec:1m due:2020-03-01",
+            m: CompletionMode::JustMark,
+            cdm: CompletionDateMode::WhenCreateDateIsPresent,
+        },
+        Test {
+            i: "2020-01-01 test rec:7d",
+            d: "x 2020-02-02 2020-01-01 test rec:7d",
+            u: "2020-01-01 test rec:7d",
+            m: CompletionMode::JustMark,
+            cdm: CompletionDateMode::WhenCreateDateIsPresent,
+        },
+        Test {
+            i: "(B) testb",
+            d: "x (B) testb",
+            u: "(B) testb",
+            m: CompletionMode::JustMark,
+            cdm: CompletionDateMode::WhenCreateDateIsPresent,
+        },
+        Test {
+            i: "(B) testb",
+            d: "x (B) 2020-02-02 testb",
+            u: "(B) testb",
+            m: CompletionMode::JustMark,
+            cdm: CompletionDateMode::AlwaysSet,
+        },
+        Test {
+            i: "(B) testb",
+            d: "x (B) testb",
+            u: "(B) testb",
+            m: CompletionMode::MovePriority,
+            cdm: CompletionDateMode::WhenCreateDateIsPresent,
+        },
+        Test {
+            i: "(B) testb",
+            d: "x 2020-02-02 (B) testb",
+            u: "(B) testb",
+            m: CompletionMode::MovePriority,
+            cdm: CompletionDateMode::AlwaysSet,
+        },
+        Test {
+            i: "(B) testb",
+            d: "x testb pri:B",
+            u: "(B) testb",
+            m: CompletionMode::PriorityToTag,
+            cdm: CompletionDateMode::WhenCreateDateIsPresent,
+        },
+        Test {
+            i: "(B) testb",
+            d: "x testb",
+            u: "testb",
+            m: CompletionMode::RemovePriority,
+            cdm: CompletionDateMode::WhenCreateDateIsPresent,
+        },
+        Test {
+            i: "(B) testb",
+            d: "x 2020-02-02 testb",
+            u: "testb",
+            m: CompletionMode::RemovePriority,
+            cdm: CompletionDateMode::AlwaysSet,
+        },
+        Test {
+            i: "(B) 2020-01-01 testc",
+            d: "x 2020-02-02 2020-01-01 (B) testc",
+            u: "(B) 2020-01-01 testc",
+            m: CompletionMode::MovePriority,
+            cdm: CompletionDateMode::WhenCreateDateIsPresent,
+        },
+        Test {
+            i: "(B) 2020-01-01 testc",
+            d: "x 2020-02-02 2020-01-01 testc pri:B",
+            u: "(B) 2020-01-01 testc",
+            m: CompletionMode::PriorityToTag,
+            cdm: CompletionDateMode::WhenCreateDateIsPresent,
+        },
+        Test {
+            i: "(B) 2020-01-01 testc",
+            d: "x 2020-02-02 2020-01-01 testc",
+            u: "2020-01-01 testc",
+            m: CompletionMode::RemovePriority,
+            cdm: CompletionDateMode::WhenCreateDateIsPresent,
+        },
+    ];
+    let base = NaiveDate::from_ymd_opt(2020, 2, 2).unwrap();
+    for d in data.iter() {
+        let mut t = Task::parse(d.i, base);
+        t.complete_with_config(base, CompletionConfig {
+            completion_mode: d.m,
+            completion_date_mode: d.cdm
+        });
+        assert_eq!(d.d, &format!("{}", t), "done '{}', mode: {:?}", d.i, d.m);
+        if t.create_date.is_some() && t.recurrence.is_none() {
+            assert_eq!(t.finish_date, Some(base));
+        }
+        if d.m != CompletionMode::RemovePriority {
+            t.uncomplete(d.m);
+            assert_eq!(d.u, &format!("{}", t), "undone '{}', mode: {:?}", d.i, d.m);
+        }
+    }
+}
+
 
 #[test]
 fn business_days_between_test() {
@@ -363,4 +513,27 @@ fn replace_recurrences() {
         t.update_tag_with_value("rec", d.w);
         assert_eq!(d.o, &t.subject, "{}-> {}", d.i, d.w);
     }
+}
+
+#[test]
+fn finish_date_with_create_date() {
+    let task = Task {
+        finished: true,
+        create_date: Some(NaiveDate::default()),
+        finish_date: NaiveDate::default().succ_opt(),
+        subject: "Feed cat".to_owned(),
+        ..Default::default()
+    };
+    assert_eq!(task.to_string(), "x 1970-01-02 1970-01-01 Feed cat")
+}
+
+#[test]
+fn finish_date_without_create_date() {
+    let task = Task {
+        finished: true,
+        finish_date: NaiveDate::default().succ_opt(),
+        subject: "Feed cat".to_owned(),
+        ..Default::default()
+    };
+    assert_eq!(task.to_string(), "x 1970-01-02 Feed cat")
 }

--- a/tests/task.rs
+++ b/tests/task.rs
@@ -220,7 +220,7 @@ fn complete_uncomplete() {
         d: &'static str,
         u: &'static str,
         m: CompletionMode,
-        cdm: CompletionDateMode
+        cdm: CompletionDateMode,
     }
     let data: Vec<Test> = vec![
         Test {
@@ -228,7 +228,7 @@ fn complete_uncomplete() {
             d: "x test",
             u: "test",
             m: CompletionMode::JustMark,
-            cdm: CompletionDateMode::WhenCreateDateIsPresent,
+            cdm: CompletionDateMode::WhenCreationDateIsPresent,
         },
         Test {
             i: "test",
@@ -242,42 +242,42 @@ fn complete_uncomplete() {
             d: "x 2020-02-02 2020-01-01 test",
             u: "2020-01-01 test",
             m: CompletionMode::JustMark,
-            cdm: CompletionDateMode::WhenCreateDateIsPresent,
+            cdm: CompletionDateMode::WhenCreationDateIsPresent,
         },
         Test {
             i: "test rec:+1m due:2020-03-01",
             d: "x test rec:+1m due:2020-03-01",
             u: "test rec:+1m due:2020-03-01",
             m: CompletionMode::JustMark,
-            cdm: CompletionDateMode::WhenCreateDateIsPresent,
+            cdm: CompletionDateMode::WhenCreationDateIsPresent,
         },
         Test {
             i: "test rec:1m due:2020-03-01",
             d: "x test rec:1m due:2020-03-01",
             u: "test rec:1m due:2020-03-01",
             m: CompletionMode::JustMark,
-            cdm: CompletionDateMode::WhenCreateDateIsPresent,
+            cdm: CompletionDateMode::WhenCreationDateIsPresent,
         },
         Test {
             i: "test rec:1m due:2020-03-01",
             d: "x test rec:1m due:2020-03-01",
             u: "test rec:1m due:2020-03-01",
             m: CompletionMode::JustMark,
-            cdm: CompletionDateMode::WhenCreateDateIsPresent,
+            cdm: CompletionDateMode::WhenCreationDateIsPresent,
         },
         Test {
             i: "2020-01-01 test rec:7d",
             d: "x 2020-02-02 2020-01-01 test rec:7d",
             u: "2020-01-01 test rec:7d",
             m: CompletionMode::JustMark,
-            cdm: CompletionDateMode::WhenCreateDateIsPresent,
+            cdm: CompletionDateMode::WhenCreationDateIsPresent,
         },
         Test {
             i: "(B) testb",
             d: "x (B) testb",
             u: "(B) testb",
             m: CompletionMode::JustMark,
-            cdm: CompletionDateMode::WhenCreateDateIsPresent,
+            cdm: CompletionDateMode::WhenCreationDateIsPresent,
         },
         Test {
             i: "(B) testb",
@@ -291,7 +291,7 @@ fn complete_uncomplete() {
             d: "x (B) testb",
             u: "(B) testb",
             m: CompletionMode::MovePriority,
-            cdm: CompletionDateMode::WhenCreateDateIsPresent,
+            cdm: CompletionDateMode::WhenCreationDateIsPresent,
         },
         Test {
             i: "(B) testb",
@@ -305,14 +305,14 @@ fn complete_uncomplete() {
             d: "x testb pri:B",
             u: "(B) testb",
             m: CompletionMode::PriorityToTag,
-            cdm: CompletionDateMode::WhenCreateDateIsPresent,
+            cdm: CompletionDateMode::WhenCreationDateIsPresent,
         },
         Test {
             i: "(B) testb",
             d: "x testb",
             u: "testb",
             m: CompletionMode::RemovePriority,
-            cdm: CompletionDateMode::WhenCreateDateIsPresent,
+            cdm: CompletionDateMode::WhenCreationDateIsPresent,
         },
         Test {
             i: "(B) testb",
@@ -326,30 +326,27 @@ fn complete_uncomplete() {
             d: "x 2020-02-02 2020-01-01 (B) testc",
             u: "(B) 2020-01-01 testc",
             m: CompletionMode::MovePriority,
-            cdm: CompletionDateMode::WhenCreateDateIsPresent,
+            cdm: CompletionDateMode::WhenCreationDateIsPresent,
         },
         Test {
             i: "(B) 2020-01-01 testc",
             d: "x 2020-02-02 2020-01-01 testc pri:B",
             u: "(B) 2020-01-01 testc",
             m: CompletionMode::PriorityToTag,
-            cdm: CompletionDateMode::WhenCreateDateIsPresent,
+            cdm: CompletionDateMode::WhenCreationDateIsPresent,
         },
         Test {
             i: "(B) 2020-01-01 testc",
             d: "x 2020-02-02 2020-01-01 testc",
             u: "2020-01-01 testc",
             m: CompletionMode::RemovePriority,
-            cdm: CompletionDateMode::WhenCreateDateIsPresent,
+            cdm: CompletionDateMode::WhenCreationDateIsPresent,
         },
     ];
     let base = NaiveDate::from_ymd_opt(2020, 2, 2).unwrap();
     for d in data.iter() {
         let mut t = Task::parse(d.i, base);
-        t.complete_with_config(base, CompletionConfig {
-            completion_mode: d.m,
-            completion_date_mode: d.cdm
-        });
+        t.complete_with_config(base, CompletionConfig { completion_mode: d.m, completion_date_mode: d.cdm });
         assert_eq!(d.d, &format!("{}", t), "done '{}', mode: {:?}", d.i, d.m);
         if t.create_date.is_some() && t.recurrence.is_none() {
             assert_eq!(t.finish_date, Some(base));
@@ -360,7 +357,6 @@ fn complete_uncomplete() {
         }
     }
 }
-
 
 #[test]
 fn business_days_between_test() {

--- a/tests/update.rs
+++ b/tests/update.rs
@@ -1,5 +1,8 @@
 use std::collections::HashMap;
-use todo_lib::{todo, todotxt::{self, CompletionConfig}};
+use todo_lib::{
+    todo,
+    todotxt::{self, CompletionConfig},
+};
 
 fn init_tasks() -> todo::TaskVec {
     let mut t = Vec::new();

--- a/tests/update.rs
+++ b/tests/update.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use todo_lib::{todo, todotxt};
+use todo_lib::{todo, todotxt::{self, CompletionConfig}};
 
 fn init_tasks() -> todo::TaskVec {
     let mut t = Vec::new();
@@ -60,6 +60,7 @@ fn add() {
 }
 
 #[test]
+#[allow(deprecated)] // tests functions that were left for back compatibility
 fn done() {
     let mut t = init_tasks();
     let orig_len = t.len();
@@ -84,6 +85,43 @@ fn done() {
     assert!(t[3].due_date == old_date);
     for i in 0..5 {
         assert!(i == 2 || t[i].finished);
+    }
+    assert_eq!(t.len(), orig_len + must_change);
+    for idx in orig_len..orig_len + must_change {
+        assert!(!t[idx].finished);
+    }
+}
+
+#[test]
+fn done_with_config() {
+    let mut t: Vec<todotxt::Task> = init_tasks();
+    let orig_len = t.len();
+    let ids: todo::IDVec = vec![0, 1, 3, 4, 10];
+    let mut must_change = 0;
+    for i in &ids {
+        if t.len() < *i {
+            continue;
+        }
+        if t[*i].finished {
+            continue;
+        }
+        if t[*i].recurrence.is_some() && (t[*i].due_date.is_some() || t[*i].threshold_date.is_some()) {
+            must_change += 1;
+        }
+    }
+
+    let old_date = t[3].due_date;
+    let completion_config = CompletionConfig {
+        completion_mode: todotxt::CompletionMode::JustMark,
+        completion_date_mode: todotxt::CompletionDateMode::AlwaysSet,
+    };
+    let changed = todo::done_with_config(&mut t, Some(&ids), completion_config);
+    assert_eq!(changed, vec![true, false, true, true, false]);
+    assert!(!t[2].finished);
+    assert!(t[3].due_date == old_date);
+    for i in 0..5 {
+        assert!(i == 2 || t[i].finished);
+        assert!(i == 2 || t[i].finish_date.is_some())
     }
     assert_eq!(t.len(), orig_len + must_change);
     for idx in orig_len..orig_len + must_change {


### PR DESCRIPTION
This work is dedicated to solve the issue [ttdl#97](https://github.com/VladimirMarkelov/ttdl/issues/97).

Completion mode enum was passed direcly, and if I followed the same principles, I would have to continue changing function signature for every new tunable. Instead, I created a new functions `complete_with_config` and `done_with_config` (names are arguable), and deprecated the old signature (back compatibility preserved). Updated documentation as well.

On the other hand, I would be happy to just change signatures of functions, there are only 2 public crates that depend on this one (one of them is same author), and anyone who relies on `todo_lib` would receive a readable compilation error with quite straightforward fix(we would also add the fix into changelog.md)

To wrap it up:  I chose a strategy to support back-compatibility that may be debatable; I welcome feedback from maintainers, prioritizing the library's quality over the work I've done so far.